### PR TITLE
Streamline Changelog Generation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,24 @@
+---
+
+#
+# Define automatically applied labels
+#
+
+github:
+  - ".github/**"
+
+documentation:
+  - "**.md"
+  - "**.cff"
+
+citation:
+  - "**.cff"
+
+chore:
+  - "**.gitignore"
+  - "**.gitattributes"
+
+test:
+  - "**/test/**"
+  - "**/tests/**"
+  - "**_test.*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,52 @@
+---
+
+#
+# Release Changelog
+#
+# See: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+#
+
+changelog:
+  exclude:
+    labels:
+      - 'skip-changelog'
+      - 'no-changelog'
+
+    authors: []
+
+  categories:
+
+    - title: "\U0001F680 Features"
+      labels:
+        - 'feature'
+        - 'enhancement'
+
+    - title: "\U0001F41B Bug Fixes"
+      labels:
+        - 'fix'
+        - 'bugfix'
+        - 'bug'
+
+    - title: "\U0001F9F0 Maintenance"
+      labels:
+        - 'chore'
+        - 'github'
+
+    - title: '⬆️ Dependencies'
+      labels:
+        - 'dependencies'
+        - 'deps'
+
+    - title: "\U0001F4D6 Documentation"
+      labels:
+        - 'documentation'
+        - 'docs'
+        - 'doc'
+
+    - title: "\U0001F6E1️ Security"
+      labels:
+        - 'security'
+
+    - title: 'Other Changes'
+      labels:
+        - "*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+---
+
+name: "Pull Request Labeler"
+run-name: "Assigning labels for #${{ github.event.number }}"
+permissions:
+  pull-requests: write
+
+on:
+  - pull_request_target
+
+jobs:
+  label:
+    name: Label Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Labels
+        uses: actions/labeler@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true


### PR DESCRIPTION
This automatically adds labels to PRs to categorise them and instructs GitHub to generate release notes based on those labels.