### PR TITLE
Specify explicit versions of dependencies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -127,13 +127,13 @@ runs:
         echo "exclude-files=$(echo "$EXCLUDE_FILES" | awk 'NF>0' | jq -R | jq -R | jq -s | jq -r tostring)" | tee -a "$GITHUB_OUTPUT"
 
     - name: "Checkout"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.1.0
       with:
         ref: ${{ github.head_ref }}
         token: ${{ inputs.token || github.token }}
 
     - name: "Setup Go"
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v3.4.0
       with:
         token: ${{ inputs.token || github.token }}
 
@@ -169,7 +169,7 @@ runs:
     - name: "Setup GPG Keys"
       if: inputs.signing-private-key != ''
       continue-on-error: true
-      uses: crazy-max/ghaction-import-gpg@v5
+      uses: crazy-max/ghaction-import-gpg@v5.2.0
       with:
         gpg_private_key: ${{ inputs.signing-private-key }}
         passphrase: ${{ inputs.signing-passphrase }}
@@ -177,7 +177,7 @@ runs:
         git_commit_gpgsign: true
 
     - name: "Commit Changes"
-      uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@v4.16.0
       with:
         commit_user_name: ${{ inputs.commit-user-name }}
         commit_user_email: ${{ inputs.commit-user-email }}


### PR DESCRIPTION
This allows electively using stable old versions or newer bleeding edge versions

Signed-off-by: Y. Meyer-Norwood <106889957+norwd@users.noreply.github.com>

<!-- LIST CHANGES HERE -->
